### PR TITLE
fix: normalisation improvements

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { Tiktoken } from '@dqbd/tiktoken';
+import { Tiktoken } from '@dqbd/tiktoken/lite';
 
 import claude from '~/claude.json';
 

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import claude from '~/claude.json';
 
 export function countTokens(text: string): number {
   const tokenizer = getTokenizer();
-  const encoded = tokenizer.encode(text);
+  const encoded = tokenizer.encode(text.normalize('NFKC'));
   tokenizer.free();
   return encoded.length;
 }

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import claude from '~/claude.json';
 
 export function countTokens(text: string): number {
   const tokenizer = getTokenizer();
-  const encoded = tokenizer.encode(text.normalize('NFKC'));
+  const encoded = tokenizer.encode(text.normalize('NFKC'), 'all');
   tokenizer.free();
   return encoded.length;
 }

--- a/tests/tokenizers.test.ts
+++ b/tests/tokenizers.test.ts
@@ -4,4 +4,8 @@ describe('countTokens', () => {
   test('small text', async () => {
     expect(countTokens('hello world!')).toEqual(3);
   });
+
+  test('text normalising', () => {
+    expect(countTokens('™')).toEqual(1);
+  });
 });

--- a/tests/tokenizers.test.ts
+++ b/tests/tokenizers.test.ts
@@ -7,5 +7,10 @@ describe('countTokens', () => {
 
   test('text normalising', () => {
     expect(countTokens('™')).toEqual(1);
+    expect(countTokens('ϰ')).toEqual(1);
+  });
+
+  test('allows special tokens', () => {
+    expect(countTokens('<EOT>')).toEqual(1);
   });
 });


### PR DESCRIPTION
Previously we would not normalise the input text before encoding which resulted in discrepancies for certain special characters, e.g. ™. These cases should now match the Python SDK.

This PR also:
- Imports Tiktoken from the `/lite` sub-module to reduce the bundle size.
- Ensures we allow special tokens, e.g. `<EOT>`